### PR TITLE
Add flag to disable double buffering

### DIFF
--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -52,6 +52,10 @@ ifeq ($(RECOVERY_GRAPHICS_USE_LINELENGTH), true)
 LOCAL_CFLAGS += -DRECOVERY_GRAPHICS_USE_LINELENGTH
 endif
 
+ifeq ($(TW_DISABLE_DOUBLE_BUFFERING), true)
+LOCAL_CFLAGS += -DTW_DISABLE_DOUBLE_BUFFERING
+endif
+
 #Remove the # from the line below to enable event logging
 #TWRP_EVENT_LOGGING := true
 ifeq ($(TWRP_EVENT_LOGGING), true)

--- a/minuitwrp/graphics.c
+++ b/minuitwrp/graphics.c
@@ -295,8 +295,12 @@ static int get_framebuffer(GGLSurface *fb)
 
     fb++;
 
+#ifndef TW_DISABLE_DOUBLE_BUFFERING
     /* check if we can use double buffering */
     if (vi.yres * fi.line_length * 2 > fi.smem_len)
+#else
+    printf("TW_DISABLE_DOUBLE_BUFFERING := true\n");
+#endif
         return fd;
 
     double_buffering = 1;


### PR DESCRIPTION
Some devices don't support double buffering, so add
the flag TW_DISABLE_DOUBLE_BUFFERING to disable it

Change-Id: Ia9c233fa229ae9c221a6c6f219b216d1753052f4
